### PR TITLE
feat(file-uploads): implement package-based restrictions for file upl…

### DIFF
--- a/src/components/DynamicForm.tsx
+++ b/src/components/DynamicForm.tsx
@@ -16,6 +16,7 @@ import { ExpressionCalculator } from '../utils/ExpressionCalculator';
 import { ConditionalLogicEvaluator } from '../utils/ConditionalLogicEvaluator';
 import { getFileBlobUrl } from '../utils/simpleFileDownload';
 import { TextExtractionReviewModal } from './TextExtractionReviewModal';
+import { UserSessionService } from '../services/userSessionService';
 
 // Helper function to convert field IDs back to user-friendly field names in formulas
 const convertFormulaToUserFriendly = (formula: string, fields: FormField[]): string => {
@@ -594,6 +595,20 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
         );
       
       case 'file': {
+        // If current user's package doesn't allow file uploads, render info instead of input
+        const canUpload = user ? UserSessionService.canUseFileUploads(user) : false;
+        if (!canUpload) {
+          return (
+            <div key={field.id} className="space-y-1">
+              <label className="block text-sm font-medium text-gray-700">
+                {field.label + (field.required ? ' *' : '')}
+              </label>
+              <div className="text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded p-3">
+                Téléversement de fichiers indisponible pour votre package actuel. Veuillez contacter votre directeur pour mettre à niveau.
+              </div>
+            </div>
+          );
+        }
         const fileAnswer = answers[field.id] as {
           fileName?: string;
           fileSize?: number;

--- a/src/components/FormBuilder.tsx
+++ b/src/components/FormBuilder.tsx
@@ -13,6 +13,8 @@ import { FormulaParser } from '../utils/FormulaParser';
 import { ConditionalLogicBuilder } from './ConditionalLogicBuilder';
 import { DesktopRecommendationInfo } from './DesktopRecommendationInfo';
 import { ConfirmationModal } from './ConfirmationModal';
+import { useAuth } from '../contexts/AuthContext';
+import { UserSessionService } from '../services/userSessionService';
 
 interface FormBuilderProps {
   onSave: (form: {
@@ -42,6 +44,8 @@ export const FormBuilder: React.FC<FormBuilderProps> = ({
   initialForm,
   isLoading = false
 }) => {
+  const { user } = useAuth();
+  const canUseFileUploads = user ? UserSessionService.canUseFileUploads(user) : false;
   // Initialiser les états avec les valeurs du formulaire existant ou vides
   const [title, setTitle] = useState(initialForm?.title || '');
   const [description, setDescription] = useState(initialForm?.description || '');
@@ -279,6 +283,14 @@ export const FormBuilder: React.FC<FormBuilderProps> = ({
     // Validation avec messages d'erreur détaillés
     const validationErrors: string[] = [];
     
+    // Package-based restriction: block file fields for packages without uploads
+    if (!canUseFileUploads) {
+      const hasFileFields = fields.some(f => f.type === 'file');
+      if (hasFileFields) {
+        validationErrors.push('Votre package actuel ne permet pas les champs de type Fichier. Supprimez-les ou mettez à niveau votre package.');
+      }
+    }
+
     if (!title.trim()) {
       validationErrors.push('Le titre du formulaire est obligatoire');
     }
@@ -585,6 +597,11 @@ export const FormBuilder: React.FC<FormBuilderProps> = ({
               <DesktopRecommendationInfo className="mb-4" />
             )}
 
+            {!canUseFileUploads && (
+              <div className="mb-3 p-3 rounded-lg bg-yellow-50 border border-yellow-200 text-yellow-800 text-sm">
+                Les téléchargements de fichiers (images/PDF) sont disponibles à partir du package Starter. Mettez à niveau pour activer ce type de champ.
+              </div>
+            )}
             {fields.length === 0 ? (
               <p className="text-gray-500 text-center py-6 sm:py-8 bg-gray-50 rounded-lg text-sm sm:text-base">
                 Aucun champ ajouté. Cliquez sur "Ajouter un champ" pour commencer.
@@ -633,7 +650,7 @@ export const FormBuilder: React.FC<FormBuilderProps> = ({
                             { value: 'textarea', label: 'Texte long' },
                             { value: 'select', label: 'Liste déroulante' },
                             { value: 'checkbox', label: 'Case à cocher' },
-                            { value: 'file', label: 'Fichier' },
+                            ...(canUseFileUploads ? [{ value: 'file', label: 'Fichier' }] : []),
                             { value: 'calculated', label: 'Champ calculé' },
                           ]}
                         />
@@ -697,7 +714,7 @@ export const FormBuilder: React.FC<FormBuilderProps> = ({
                         </div>
                       )}
 
-                      {field.type === 'file' && (
+                      {field.type === 'file' && canUseFileUploads && (
                         <FileTypeSelector
                           label="Types de fichiers acceptés"
                           selectedTypes={field.acceptedTypes || []}

--- a/src/components/UserFriendlyErrorModal.tsx
+++ b/src/components/UserFriendlyErrorModal.tsx
@@ -195,3 +195,4 @@ export const useUserFriendlyError = () => {
     ErrorModal
   };
 };
+

--- a/src/config/packageFeatures.ts
+++ b/src/config/packageFeatures.ts
@@ -43,6 +43,8 @@ export interface PackageFeatures {
   
   // Fonctionnalités d'import
   fileImport: boolean;
+  // Téléversement de fichiers dans les formulaires (images/pdf)
+  allowFileUploads: boolean;
   
   // Fonctionnalités de branding
   customBranding: boolean;
@@ -118,6 +120,7 @@ export const PACKAGE_FEATURES: Record<PackageType, PackageFeatures> = {
     
     // Fonctionnalités d'import
     fileImport: false,
+    allowFileUploads: false,
     
     // Fonctionnalités de branding
     customBranding: false,
@@ -161,6 +164,7 @@ export const PACKAGE_FEATURES: Record<PackageType, PackageFeatures> = {
     
     // Fonctionnalités d'import
     fileImport: true, // Available to Starter and Standard
+    allowFileUploads: true,
     
     // Fonctionnalités de branding
     customBranding: false,
@@ -204,6 +208,7 @@ export const PACKAGE_FEATURES: Record<PackageType, PackageFeatures> = {
     
     // Fonctionnalités d'import
     fileImport: true, // Available to Starter and Standard
+    allowFileUploads: true,
     
     // Fonctionnalités de branding
     customBranding: false,

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -295,7 +295,7 @@ export const NotificationsPage: React.FC = () => {
         <PushNotificationSettings />
 
         {/* Test Notification Buttons */}
-        <Card className="p-6">
+        {/* <Card className="p-6">
           <div className="flex items-center gap-3 mb-4">
             <MessageSquare className="w-6 h-6 text-green-600" />
             <h3 className="text-lg font-semibold">Tester les notifications</h3>
@@ -341,7 +341,7 @@ export const NotificationsPage: React.FC = () => {
               Test Instruction
             </Button>
           </div>
-        </Card>
+        </Card> */}
 
         {/* Notifications List */}
         <Card className="p-6">

--- a/src/services/firebaseErrorHandler.ts
+++ b/src/services/firebaseErrorHandler.ts
@@ -213,3 +213,4 @@ export async function withFirebaseErrorHandling<T>(
   
   throw lastError;
 }
+

--- a/src/services/userSessionService.ts
+++ b/src/services/userSessionService.ts
@@ -358,6 +358,24 @@ export class UserSessionService {
   }
 
   /**
+   * Check if user/package can use file uploads in forms (images/PDF)
+   * Directors and employees with director access inherit director's package
+   */
+  static canUseFileUploads(user: User): boolean {
+    if (user.role !== 'directeur' && !(user.role === 'employe' && user.hasDirectorDashboardAccess)) {
+      return false;
+    }
+
+    const currentSession = SubscriptionSessionService.getCurrentSession(user);
+    if (!currentSession) {
+      return false;
+    }
+
+    const features = PACKAGE_FEATURES[currentSession.packageType];
+    return !!features && (features as any).allowFileUploads === true;
+  }
+
+  /**
    * Check if user can perform an action based on limits
    * Note: Only directors and employees with director access have subscription sessions
    */


### PR DESCRIPTION
…oads in forms

- Added functionality to restrict file upload fields based on user package permissions.
- Introduced user feedback messages for packages that do not allow file uploads.
- Updated the DynamicForm and FormBuilder components to check user permissions and display appropriate UI elements.
- Enhanced the UserSessionService to include a method for checking file upload capabilities based on user roles and subscription packages.
- Updated package features configuration to include file upload permissions.